### PR TITLE
Force curl to maintain POST after a 301 redirect

### DIFF
--- a/pterodactyl/pterodactyl.php
+++ b/pterodactyl/pterodactyl.php
@@ -49,6 +49,7 @@ function pterodactyl_API(array $params, $endpoint, array $data = [], $method = "
     curl_setopt($curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
     curl_setopt($curl, CURLOPT_USERAGENT, "Pterodactyl-WHMCS");
     curl_setopt($curl, CURLOPT_FOLLOWLOCATION, 1);
+    curl_setopt($curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_301);
     curl_setopt($curl, CURLOPT_TIMEOUT, 5);
 
     $headers = [


### PR DESCRIPTION
Update WHMCS module to maintain the request type after 301 redirect.

When a POST is made to a URL that results in a 301 redirect the request type is changed from POST to GET.  This setting curl to maintain the POST mode when it receives a 301 redirect.  Avoids a timeout when sending a GET request to the user API if HTTPS is not explicitly specified in the URL.