### PR TITLE
Fix padding on admin client area links

### DIFF
--- a/pterodactyl/pterodactyl.php
+++ b/pterodactyl/pterodactyl.php
@@ -596,8 +596,9 @@ function pterodactyl_LoginLink(array $params) {
         if(!isset($serverId)) return;
 
         $hostname = pterodactyl_GetHostname($params);
-        echo '[<a href="'.$hostname.'/admin/servers/view/' . $serverId . '" target="_blank">Go to Service</a>]';
-        echo '<p style="float: right">[<a href="https://github.com/pterodactyl/whmcs/issues" target="_blank">Report A Bug</a>]</p>';
+        echo '<a style="padding-right:3px" href="'.$hostname.'/admin/servers/view/' . $serverId . '" target="_blank">[Go to Service]</a>';
+        echo '<p style="float:right; padding-right:1.3%">[<a href="https://github.com/pterodactyl/whmcs/issues" target="_blank">Report A Bug</a>]</p>';
+        # echo '<p style="float: right">[<a href="https://github.com/pterodactyl/whmcs/issues" target="_blank">Report A Bug</a>]</p>';
     } catch(Exception $err) {
         // Ignore
     }


### PR DESCRIPTION
Adjusted padding for "Go To Service" and "Report A Bug" links to prevent displaying outside content box