### PR TITLE
Add allocation IP to “Dedicated IP” Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module requires the panel to be on version 1.0.0 and above, if you need one
 
 1. Download/Git clone this repository.
 2. Move the ``pterodactyl/`` folder into ``<path to whmcs>/modules/servers/``.
-3. Create API Credentials with these permissions: ![Image](https://i.imgur.com/abQQVtd.png)
+3. Create API Credentials with these permissions: ![Image](https://i.imgur.com/oeoTyBO.png)
 4. In WHMCS 8+ navigate to System Settings → Servers. In WHMCS 7 or below navigate to Setup → Products/Services → Servers
 5. Create new server, fill the name with anything you want, hostname as the url to the panel either as an IP or domain. For example: ``123.123.123.123`` or ``my.pterodactyl.panel``
 6. Change Server Type to Pterodactyl, leave username empty, fill the password field with your generated API Key.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This module requires the panel to be on version 1.0.0 and above, if you need one
 
 1. Download/Git clone this repository.
 2. Move the ``pterodactyl/`` folder into ``<path to whmcs>/modules/servers/``.
-3. Create API Credentials with these permissions: ![Image](https://i.imgur.com/oeoTyBO.png)
+3. Create API Credentials with these permissions: ![Image](https://i.imgur.com/abQQVtd.png)
 4. In WHMCS 8+ navigate to System Settings → Servers. In WHMCS 7 or below navigate to Setup → Products/Services → Servers
 5. Create new server, fill the name with anything you want, hostname as the url to the panel either as an IP or domain. For example: ``123.123.123.123`` or ``my.pterodactyl.panel``
 6. Change Server Type to Pterodactyl, leave username empty, fill the password field with your generated API Key.

--- a/pterodactyl/pterodactyl.php
+++ b/pterodactyl/pterodactyl.php
@@ -414,8 +414,6 @@ function pterodactyl_CreateAccount(array $params) {
 		$_pages = $_allocations['meta']['pagination']['total_pages'];
 		$_currentPage = $_allocations['meta']['pagination']['current_page'];
 		
-		$_IP = "";
-		$_Port = "";
 		
 			if ($_pages == 1){
 				foreach($_allocations['data'] as $alloc){
@@ -439,10 +437,12 @@ function pterodactyl_CreateAccount(array $params) {
 				
 			}
 
+        // Check if IP & Port field have value. Prevents ":" being added if API error
+        if (isset($_IP) && isset($_Port)) {
         try {
 			$query = Capsule::table('tblhosting')->where('id', $params['serviceid'])->where('userid', $params['userid'])->update(array('dedicatedip' => $_IP . ":" . $_Port));
 		} catch (Exception $e) { return $e->getMessage() . "<br />" . $e->getTraceAsString(); }
-		
+    }
 
         Capsule::table('tblhosting')->where('id', $params['serviceid'])->update([
             'username' => '',


### PR DESCRIPTION
Adds the allocation IP assigned to the server at creation to the dedicated IP field on whmcs admin. 

Credits: @conandoyl
Resolves: #102 

tested on whmcs 8.0 